### PR TITLE
Backport change from PR 190 to fix downstream qpsolvers-eigen compilation

### DIFF
--- a/recipe/190.patch
+++ b/recipe/190.patch
@@ -1,0 +1,13 @@
+diff --git a/include/OsqpEigen/Constants.hpp b/include/OsqpEigen/Constants.hpp
+index 6dde607..8b1029a 100644
+--- a/include/OsqpEigen/Constants.hpp
++++ b/include/OsqpEigen/Constants.hpp
+@@ -30,7 +30,7 @@ enum class Status : int
+     PrimalInfeasible = OSQP_PRIMAL_INFEASIBLE,
+     DualInfeasible = OSQP_DUAL_INFEASIBLE,
+     Sigint = OSQP_SIGINT,
+-#ifdef PROFILING
++#if defined(PROFILING) || defined(OSQP_EIGEN_OSQP_IS_V1)
+     TimeLimitReached = OSQP_TIME_LIMIT_REACHED,
+ #endif // ifdef PROFILING
+     NonCvx = OSQP_NON_CVX,

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,9 +8,11 @@ package:
 source:
   url: https://github.com/robotology/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
   sha256: 2f6605f1f1a60b54b708b2a97b61f2a3b136c388037d9d7ef0228002de8cad39
+  patches:
+    - 190.patch
 
 build:
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x.x') }}
 


### PR DESCRIPTION
See https://github.com/conda-forge/qpsolvers-eigen-feedstock/pull/5 and https://github.com/robotology/osqp-eigen/pull/190 .

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
